### PR TITLE
Add teacher-only admin mode for registration changes

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,13 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import json
+import secrets
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +20,13 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+teachers_file = current_dir / "teachers.json"
+with teachers_file.open("r", encoding="utf-8") as f:
+    teachers = json.load(f)
+
+# In-memory session store keyed by auth token.
+teacher_sessions = {}
 
 # In-memory activity database
 activities = {
@@ -88,9 +97,44 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def teacher_login(username: str, password: str):
+    """Authenticate a teacher and return a session token."""
+    if teachers.get(username) != password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = secrets.token_urlsafe(32)
+    teacher_sessions[token] = username
+    return {"message": f"Logged in as {username}", "token": token, "username": username}
+
+
+@app.get("/auth/status")
+def auth_status(x_teacher_token: str | None = Header(default=None)):
+    """Return whether the requester is an authenticated teacher."""
+    if not x_teacher_token or x_teacher_token not in teacher_sessions:
+        return {"authenticated": False}
+
+    return {"authenticated": True, "username": teacher_sessions[x_teacher_token]}
+
+
+@app.post("/auth/logout")
+def teacher_logout(x_teacher_token: str | None = Header(default=None)):
+    """Invalidate a teacher session token."""
+    if x_teacher_token:
+        teacher_sessions.pop(x_teacher_token, None)
+    return {"message": "Logged out"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str,
+                        x_teacher_token: str | None = Header(default=None)):
     """Sign up a student for an activity"""
+    if not x_teacher_token or x_teacher_token not in teacher_sessions:
+        raise HTTPException(
+            status_code=401,
+            detail="Teacher login required to register students"
+        )
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +155,15 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str,
+                             x_teacher_token: str | None = Header(default=None)):
     """Unregister a student from an activity"""
+    if not x_teacher_token or x_teacher_token not in teacher_sessions:
+        raise HTTPException(
+            status_code=401,
+            detail="Teacher login required to unregister students"
+        )
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,70 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const authRequiredNote = document.getElementById("auth-required-note");
+  const userMenuToggle = document.getElementById("user-menu-toggle");
+  const userMenuPanel = document.getElementById("user-menu-panel");
+  const userMenu = document.querySelector(".user-menu");
+  const showLoginFormButton = document.getElementById("show-login-form");
+  const logoutButton = document.getElementById("logout-button");
+  const loginForm = document.getElementById("login-form");
+  const authStatus = document.getElementById("auth-status");
+
+  let teacherToken = localStorage.getItem("teacherToken") || "";
+  let teacherUsername = localStorage.getItem("teacherUsername") || "";
+
+  function setMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function updateAuthUI() {
+    const isLoggedIn = Boolean(teacherToken);
+    signupForm.classList.toggle("hidden", !isLoggedIn);
+    authRequiredNote.classList.toggle("hidden", isLoggedIn);
+
+    if (isLoggedIn) {
+      authStatus.textContent = `Logged in as ${teacherUsername}`;
+      showLoginFormButton.classList.add("hidden");
+      logoutButton.classList.remove("hidden");
+      loginForm.classList.add("hidden");
+    } else {
+      authStatus.textContent = "Not logged in";
+      showLoginFormButton.classList.remove("hidden");
+      logoutButton.classList.add("hidden");
+    }
+  }
+
+  async function validateSession() {
+    if (!teacherToken) {
+      updateAuthUI();
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/status", {
+        headers: {
+          "X-Teacher-Token": teacherToken,
+        },
+      });
+      const result = await response.json();
+
+      if (!result.authenticated) {
+        teacherToken = "";
+        teacherUsername = "";
+        localStorage.removeItem("teacherToken");
+        localStorage.removeItem("teacherUsername");
+      }
+    } catch (error) {
+      console.error("Error validating session:", error);
+    }
+
+    updateAuthUI();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +76,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML =
+        '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +96,9 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}" ${
+                        teacherToken ? "" : "disabled"
+                      }>❌</button></li>`
                   )
                   .join("")}
               </ul>
@@ -57,9 +125,11 @@ document.addEventListener("DOMContentLoaded", () => {
       });
 
       // Add event listeners to delete buttons
-      document.querySelectorAll(".delete-btn").forEach((button) => {
-        button.addEventListener("click", handleUnregister);
-      });
+      if (teacherToken) {
+        document.querySelectorAll(".delete-btn").forEach((button) => {
+          button.addEventListener("click", handleUnregister);
+        });
+      }
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -80,32 +150,24 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: {
+            "X-Teacher-Token": teacherToken,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        setMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        setMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      setMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -124,37 +186,102 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: {
+            "X-Teacher-Token": teacherToken,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        setMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        setMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      setMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  userMenuToggle.addEventListener("click", () => {
+    userMenuPanel.classList.toggle("hidden");
+  });
+
+  showLoginFormButton.addEventListener("click", () => {
+    loginForm.classList.toggle("hidden");
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("teacher-username").value.trim();
+    const password = document.getElementById("teacher-password").value;
+
+    try {
+      const response = await fetch(
+        `/auth/login?username=${encodeURIComponent(
+          username
+        )}&password=${encodeURIComponent(password)}`,
+        {
+          method: "POST",
+        }
+      );
+      const result = await response.json();
+
+      if (!response.ok) {
+        setMessage(result.detail || "Login failed", "error");
+        return;
+      }
+
+      teacherToken = result.token;
+      teacherUsername = result.username;
+      localStorage.setItem("teacherToken", teacherToken);
+      localStorage.setItem("teacherUsername", teacherUsername);
+      loginForm.reset();
+      loginForm.classList.add("hidden");
+      updateAuthUI();
+      fetchActivities();
+      setMessage(result.message, "success");
+    } catch (error) {
+      setMessage("Failed to log in. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  logoutButton.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: {
+          "X-Teacher-Token": teacherToken,
+        },
+      });
+    } catch (error) {
+      console.error("Error logging out:", error);
+    }
+
+    teacherToken = "";
+    teacherUsername = "";
+    localStorage.removeItem("teacherToken");
+    localStorage.removeItem("teacherUsername");
+    updateAuthUI();
+    fetchActivities();
+    setMessage("Logged out", "success");
+  });
+
+  document.addEventListener("click", (event) => {
+    if (!userMenu.contains(event.target)) {
+      userMenuPanel.classList.add("hidden");
+    }
+  });
+
   // Initialize app
+  validateSession();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,25 @@
   </head>
   <body>
     <header>
+      <div class="user-menu">
+        <button id="user-menu-toggle" type="button" class="icon-button" aria-label="User menu">👤</button>
+        <div id="user-menu-panel" class="user-menu-panel hidden">
+          <p id="auth-status" class="auth-status">Not logged in</p>
+          <button id="show-login-form" type="button">Login</button>
+          <button id="logout-button" type="button" class="hidden">Logout</button>
+          <form id="login-form" class="hidden">
+            <div class="form-group">
+              <label for="teacher-username">Username:</label>
+              <input type="text" id="teacher-username" required />
+            </div>
+            <div class="form-group">
+              <label for="teacher-password">Password:</label>
+              <input type="password" id="teacher-password" required />
+            </div>
+            <button type="submit">Sign In</button>
+          </form>
+        </div>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>
@@ -23,6 +42,7 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="auth-required-note" class="info">Teacher login is required to register or unregister students.</p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,6 +16,7 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
@@ -26,6 +27,60 @@ header {
 
 header h1 {
   margin-bottom: 10px;
+}
+
+.user-menu {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+.icon-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  font-size: 18px;
+}
+
+.icon-button:hover {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.user-menu-panel {
+  position: absolute;
+  right: 0;
+  margin-top: 8px;
+  width: 280px;
+  text-align: left;
+  color: #333;
+  background-color: #fff;
+  border-radius: 6px;
+  padding: 12px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+  z-index: 10;
+}
+
+.auth-status {
+  margin-bottom: 10px;
+  font-size: 14px;
+  color: #1a237e;
+  font-weight: bold;
+}
+
+.user-menu-panel button {
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+#login-form {
+  margin-top: 4px;
+}
+
+#auth-required-note {
+  margin-bottom: 14px;
 }
 
 main {
@@ -119,6 +174,11 @@ section h3 {
   padding: 2px 5px;
   transition: all 0.2s;
   border-radius: 3px;
+}
+
+.delete-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .delete-btn:hover {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,4 @@
+{
+  "teacher.alex": "teach123",
+  "teacher.morgan": "classroom456"
+}


### PR DESCRIPTION
## Summary
Implements issue #5 by introducing a teacher login flow and restricting student registration changes to authenticated teachers.

## What changed
- Added teacher credential store in `src/teachers.json`
- Added backend auth endpoints:
  - `POST /auth/login`
  - `GET /auth/status`
  - `POST /auth/logout`
- Protected write endpoints so only logged-in teachers can:
  - register students (`POST /activities/{activity_name}/signup`)
  - unregister students (`DELETE /activities/{activity_name}/unregister`)
- Added a top-right user menu in the UI with login/logout controls
- Hid registration form when not logged in and displayed an auth-required note
- Disabled unregister buttons for non-authenticated users
- Stored teacher session token in `localStorage` and sent it via `X-Teacher-Token`

## Validation
- Python compile check passed (`python -m compileall src`)
- API smoke test via curl confirmed:
  - unauthenticated signup returns `401`
  - login succeeds with sample teacher credentials
  - authenticated signup/unregister return `200`

## Notes
- Session storage is in-memory and resets on server restart (acceptable for this exercise scope).